### PR TITLE
Design: 후원자 연락처 변경 안내 문구 삭제

### DIFF
--- a/front/src/pages/FundingProgress.jsx
+++ b/front/src/pages/FundingProgress.jsx
@@ -160,7 +160,6 @@ const FundingProgress = () => {
                                     </div>
                                 </div>
                                 <Typography>* 위 연락처와 이메일로 후원 관련 소식이 전달됩니다.</Typography>
-                                <Typography>* 연락처 및 이메일 변경은 프로필 &gt; 설정 에서 가능합니다.</Typography>
                             </div>
 
                             <Button


### PR DESCRIPTION
- 사용자 개인정보(이메일, 전화번로)를 수정하는 기능을 제거했기 때문에 안내 문구도 제거